### PR TITLE
Consolidate service worker lifecycle handlers

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,9 +1,11 @@
 self.addEventListener('install', (event) => {
   console.log('Service Worker: Instal·lat');
+  self.skipWaiting(); // 🔁 activa la nova versió immediatament
 });
 
 self.addEventListener('activate', (event) => {
   console.log('Service Worker: Actiu');
+  event.waitUntil(clients.claim()); // 🧠 força que totes les pàgines usin el nou SW
 });
 
 self.addEventListener('fetch', (event) => {
@@ -11,13 +13,6 @@ self.addEventListener('fetch', (event) => {
   event.respondWith(fetch(event.request));
 });
 
-self.addEventListener('install', event => {
-  self.skipWaiting(); // 🔁 activa la nova versió immediatament
-});
-
-self.addEventListener('activate', event => {
-  event.waitUntil(clients.claim()); // 🧠 força que totes les pàgines usin el nou SW
-});
 self.addEventListener('message', event => {
   if (event.data === 'skipWaiting') {
     self.skipWaiting();


### PR DESCRIPTION
## Summary
- merge duplicate `install` listeners into one handler
- merge duplicate `activate` listeners into one handler
- keep `fetch` and `message` handlers the same

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68480ef6d2c4832e96a25cd4e5b8e0b4