### PR TITLE
Explain API key requirement and handle missing key

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ Multi YouTube Viewer is a progressive web app for watching up to four YouTube vi
 - Use **▶️ Reproduir tots** to play all videos and **⏸️ Pausar tots** to pause them.
 - Links using `youtube.com/live/...` are converted to regular watch URLs.
 
+## Check live streams
+
+The **Check Live Streams** button queries the YouTube Data API to see which
+channels in `canals.json` are broadcasting live. To use it you must provide your
+own API key:
+
+1. Create a project in the Google Cloud Console and enable the *YouTube Data API v3*.
+2. Generate an API key and copy it into `canal.js` by editing the `API_KEY`
+   constant.
+3. Reload the page and press **Check Live Streams**.
+
+Only public live streams will be returned; unlisted broadcasts won't appear in
+the results.
+
 ## Updating channel list
 
 1. Install dependencies with `npm install`.

--- a/canal.js
+++ b/canal.js
@@ -1,3 +1,4 @@
+// Introduceix aquí la teva clau de l'API de YouTube Data
 const API_KEY = '';
 
 async function getChannels() {
@@ -8,6 +9,10 @@ async function getChannels() {
 async function checkLiveStreams() {
   const results = document.getElementById('liveResults');
   results.textContent = 'Comprovant...';
+  if (!API_KEY) {
+    results.textContent = 'Cal definir API_KEY a canal.js';
+    return;
+  }
   const channels = await getChannels();
   results.innerHTML = '';
   for (const channel of channels) {


### PR DESCRIPTION
## Summary
- document how to use the **Check Live Streams** feature
- show a warning on the page if `API_KEY` isn't defined

## Testing
- `npm test` *(fails: Missing script)*
- `npm run fetch-channels` *(fails: Cannot find module 'cheerio')*

------
https://chatgpt.com/codex/tasks/task_e_68484d67c694832e858bc5d42eb4ead3