### PR TITLE
Handle YouTube API errors

### DIFF
--- a/canal.js
+++ b/canal.js
@@ -20,6 +20,12 @@ async function checkLiveStreams() {
     try {
       const res = await fetch(url);
       const data = await res.json();
+
+      if (!res.ok || data.error) {
+        console.error('API error', data.error || res.statusText);
+        continue;
+      }
+
       if (data.items && data.items.length > 0) {
         const videoId = data.items[0].id.videoId;
         const li = document.createElement('li');


### PR DESCRIPTION
## Summary
- surface API errors when checking live streams

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68487d678f8c832ea0f90949aef7b576