### PR TITLE
Add CLI script for checking live YouTube channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ To use the Data API method you need your own key:
 Only public live streams will be returned; unlisted broadcasts won't appear in
 the results.
 
+### Command line usage
+
+You can also check live streams from the terminal. Run
+`npm run check-live` and the script will print the watch URLs of any channels
+currently broadcasting live. Set the `API_KEY` environment variable if you want
+to use the YouTube Data API:
+
+```bash
+API_KEY=YOUR_KEY npm run check-live
+```
+
 ## Updating channel list
 
 1. Install dependencies with `npm install`.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "description": "Multi YouTube Viewer PWA",
   "scripts": {
-    "fetch-channels": "node scripts/fetch_channels.js"
+    "fetch-channels": "node scripts/fetch_channels.js",
+    "check-live": "node scripts/check_live.js"
   },
   "dependencies": {
     "cheerio": "^1.0.0-rc.12"

--- a/scripts/check_live.js
+++ b/scripts/check_live.js
@@ -1,0 +1,49 @@
+const fs = require('fs/promises');
+
+const API_KEY = process.env.API_KEY || '';
+
+async function loadChannels() {
+  const data = await fs.readFile('canals.json', 'utf8');
+  return JSON.parse(data);
+}
+
+async function checkChannelLive(channel) {
+  if (API_KEY) {
+    const apiUrl = `https://www.googleapis.com/youtube/v3/search?part=snippet&channelId=${channel.channelId}&eventType=live&type=video&key=${API_KEY}`;
+    const res = await fetch(apiUrl);
+    const data = await res.json();
+    if (res.ok && data.items && data.items.length > 0) {
+      return `https://www.youtube.com/watch?v=${data.items[0].id.videoId}`;
+    }
+    return null;
+  }
+
+  const proxyUrl = `https://corsproxy.io/?https://www.youtube.com/channel/${channel.channelId}/live`;
+  const res = await fetch(proxyUrl, { redirect: 'follow' });
+  if (!res.ok) return null;
+  const finalUrl = decodeURIComponent(res.url.replace('https://corsproxy.io/?', ''));
+  const match = finalUrl.match(/[?&]v=([^&]+)/);
+  if (match) {
+    return `https://www.youtube.com/watch?v=${match[1]}`;
+  }
+  return null;
+}
+
+async function main() {
+  const channels = await loadChannels();
+  for (const channel of channels) {
+    try {
+      const url = await checkChannelLive(channel);
+      if (url) {
+        console.log(`${channel.name}: ${url}`);
+      }
+    } catch (err) {
+      console.error('Error checking', channel.channelId, err.message);
+    }
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `scripts/check_live.js` to fetch live stream URLs from `canals.json`
- expose script with `npm run check-live`
- document CLI usage in README

## Testing
- `npm run check-live` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68492c7e8988832ea5a94cc58a7d0cab