### PR TITLE
Shrink control buttons

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -53,8 +53,13 @@ input {
   margin-top: 10px;
   display: flex;
   justify-content: center;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 10px;
+}
+
+.controls button {
+  padding: 6px 12px;
+  font-size: 0.8em;
 }
 
 iframe {


### PR DESCRIPTION
## Summary
- make control buttons smaller and keep them on one line

## Testing
- `npm test` *(fails: Missing script)*
- `npm run check-live` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684a7a4c3fa8832e9383aac0ae9ecb69