### PR TITLE
Fix fallback live stream detection

### DIFF
--- a/canal.js
+++ b/canal.js
@@ -39,13 +39,16 @@ async function checkLiveStreams() {
       }
     } else {
       try {
-        const proxyUrl = `https://www.youtube.com/channel/${channel.channelId}/live`;
+        const proxyUrl =
+          `https://corsproxy.io/?https://www.youtube.com/channel/${channel.channelId}/live`;
         const res = await fetch(proxyUrl, { redirect: 'follow' });
         if (!res.ok) {
           console.error('Fallback fetch error', res.statusText);
           continue;
         }
-        const finalUrl = proxyUrl;
+        const finalUrl = decodeURIComponent(
+          res.url.replace('https://corsproxy.io/?', '')
+        );
         const match = finalUrl.match(/[?&]v=([^&]+)/);
         if (match) {
           const videoId = match[1];
@@ -58,7 +61,11 @@ async function checkLiveStreams() {
           results.appendChild(li);
         }
       } catch (err) {
-        console.error('Error checking channel without API', channel.channelId, err);
+        console.error(
+          'Error checking channel without API',
+          channel.channelId,
+          err
+        );
       }
     }
   }


### PR DESCRIPTION
## Summary
- fix checkLive button by using a CORS proxy when no API key is configured

## Testing
- `npm run check-live` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684a7d28a394832e9b91f504b21066e3