### PR TITLE
Fix clearing of live results

### DIFF
--- a/canal.js
+++ b/canal.js
@@ -11,7 +11,7 @@ async function checkLiveStreams() {
   const results = document.getElementById('liveResults');
   results.textContent = 'Comprovant...';
   const channels = await getChannels();
-  results.innerHTML = '';
+  let cleared = false;
   for (const channel of channels) {
     if (API_KEY) {
       const url = `https://www.googleapis.com/youtube/v3/search?part=snippet&channelId=${channel.channelId}&eventType=live&type=video&key=${API_KEY}`;
@@ -25,6 +25,10 @@ async function checkLiveStreams() {
         }
 
         if (data.items && data.items.length > 0) {
+          if (!cleared) {
+            results.innerHTML = '';
+            cleared = true;
+          }
           const videoId = data.items[0].id.videoId;
           const li = document.createElement('li');
           const a = document.createElement('a');
@@ -51,6 +55,10 @@ async function checkLiveStreams() {
         );
         const match = finalUrl.match(/[?&]v=([^&]+)/);
         if (match) {
+          if (!cleared) {
+            results.innerHTML = '';
+            cleared = true;
+          }
           const videoId = match[1];
           const li = document.createElement('li');
           const a = document.createElement('a');
@@ -69,7 +77,7 @@ async function checkLiveStreams() {
       }
     }
   }
-  if (!results.hasChildNodes()) {
+  if (!cleared) {
     results.textContent = 'No hi ha transmissions en directe ara mateix.';
   }
 }


### PR DESCRIPTION
## Summary
- preserve the "Comprovant" status message until live channels are found

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a7ee8db80832e8969f3ace548d71d