### PR TITLE
Handle /live/ URLs in live checks

### DIFF
--- a/canal.js
+++ b/canal.js
@@ -49,7 +49,7 @@ async function checkLiveStreams() {
         const finalUrl = decodeURIComponent(
           res.url.replace('https://corsproxy.io/?', '')
         );
-        const match = finalUrl.match(/[?&]v=([^&]+)/);
+        const match = finalUrl.match(/(?:[?&]v=|\/live\/)([^&/]+)/);
         if (match) {
           const videoId = match[1];
           const li = document.createElement('li');

--- a/scripts/check_live.js
+++ b/scripts/check_live.js
@@ -22,7 +22,7 @@ async function checkChannelLive(channel) {
   const res = await fetch(proxyUrl, { redirect: 'follow' });
   if (!res.ok) return null;
   const finalUrl = decodeURIComponent(res.url.replace('https://corsproxy.io/?', ''));
-  const match = finalUrl.match(/[?&]v=([^&]+)/);
+  const match = finalUrl.match(/(?:[?&]v=|\/live\/)([^&/]+)/);
   if (match) {
     return `https://www.youtube.com/watch?v=${match[1]}`;
   }


### PR DESCRIPTION
## Summary
- support `/live/<videoId>` links when checking channel live status

## Testing
- `npm run check-live` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684a7eea0468832e875d9537226dff87