### PR TITLE
Specify Node engine requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ the results.
 
 ### Command line usage
 
+This project requires **Node.js 18** or newer to run the command line scripts.
+
 You can also check live streams from the terminal. Run
 `npm run check-live` and the script will print the watch URLs of any channels
 currently broadcasting live. Set the `API_KEY` environment variable if you want

--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
   },
   "dependencies": {
     "cheerio": "^1.0.0-rc.12"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }


### PR DESCRIPTION
## Summary
- enforce Node.js 18+ via the `engines` field
- document the Node requirement in the CLI usage instructions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a7eeca878832ea4757e72c4ac4541