### PR TITLE
Improve live detection fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ listed in `canals.json`. Each channel entry now includes a `handle` (e.g.
 to checking each channel's `/live` page—preferring the handle when available—
 through a CORS proxy.
 
+When a live stream is found it appears in a list under the button. Each result
+includes a **Copiar** button that places the live URL into the first empty video
+field of the form so you can easily load it.
+
 
 To use the Data API method you need your own key:
 

--- a/canal.js
+++ b/canal.js
@@ -71,7 +71,11 @@ async function checkLiveStreams() {
         const finalUrl = decodeURIComponent(
           res.url.replace('https://corsproxy.io/?', '')
         );
-        const match = finalUrl.match(/(?:[?&]v=|\/live\/)([^&/]+)/);
+        let match = finalUrl.match(/(?:[?&]v=|\/live\/)([^&/?]+)/);
+        if (!match) {
+          const html = await res.text();
+          match = html.match(/"(?:watch\?v=|videoId\":\")([\w-]{11})/);
+        }
         if (match) {
           if (!cleared) {
             results.innerHTML = '';

--- a/scripts/check_live.js
+++ b/scripts/check_live.js
@@ -25,7 +25,11 @@ async function checkChannelLive(channel) {
   const res = await fetch(proxyUrl, { redirect: 'follow' });
   if (!res.ok) return null;
   const finalUrl = decodeURIComponent(res.url.replace('https://corsproxy.io/?', ''));
-  const match = finalUrl.match(/(?:[?&]v=|\/live\/)([^&/]+)/);
+  let match = finalUrl.match(/(?:[?&]v=|\/live\/)([^&/?]+)/);
+  if (!match) {
+    const html = await res.text();
+    match = html.match(/"(?:watch\?v=|videoId\":\")([\w-]{11})/);
+  }
   if (match) {
     return `https://www.youtube.com/watch?v=${match[1]}`;
   }


### PR DESCRIPTION
## Summary
- detect YouTube video ID from page HTML if redirect URL lacks it
- document the "Copiar" button in the README

## Testing
- `npm run check-live` *(fails: fetch errors)*

------
https://chatgpt.com/codex/tasks/task_e_684a9686c560832ea111de76337bdfad