### PR TITLE
Add WebSub live stream listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,19 @@ API_KEY=YOUR_KEY npm run check-live
 1. Install dependencies with `npm install`.
 2. Run `npm run fetch-channels` to scrape YouTube channels and update `canals.json` with their IDs and handles.
 
+## WebSub listener
+
+The `websub_server.js` script subscribes to a channel's WebSub feed and logs a
+message whenever a live stream starts. Set the environment variables
+`CHANNEL_ID`, `API_KEY` and `CALLBACK_URL` before running it:
+
+```bash
+CHANNEL_ID=UC... API_KEY=YOUR_KEY CALLBACK_URL=https://example.com/websub \
+  node websub_server.js
+```
+
+The script listens on `PORT` (default `3000`) and automatically subscribes to
+the YouTube hub. Whenever a notification arrives it checks the video ID through
+the YouTube Data API and prints a line if the broadcast is live.
+
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Multi YouTube Viewer PWA",
   "scripts": {
     "fetch-channels": "node scripts/fetch_channels.js",
-    "check-live": "node scripts/check_live.js"
+    "check-live": "node scripts/check_live.js",
+    "websub-server": "node websub_server.js"
   },
   "dependencies": {
     "cheerio": "^1.0.0-rc.12"

--- a/websub_server.js
+++ b/websub_server.js
@@ -1,0 +1,100 @@
+const http = require('http');
+const { URL, URLSearchParams } = require('url');
+
+const PORT = process.env.PORT || 3000;
+const CALLBACK_URL = process.env.CALLBACK_URL || 'http://localhost:' + PORT + '/websub';
+const CHANNEL_ID = process.env.CHANNEL_ID;
+const API_KEY = process.env.API_KEY;
+
+if (!CHANNEL_ID) {
+  console.error('Missing CHANNEL_ID environment variable');
+  process.exit(1);
+}
+if (!API_KEY) {
+  console.error('Missing API_KEY environment variable');
+  process.exit(1);
+}
+
+async function subscribe() {
+  const hubUrl = 'https://pubsubhubbub.appspot.com/subscribe';
+  const topic = `https://www.youtube.com/xml/feeds/videos.xml?channel_id=${CHANNEL_ID}`;
+  const params = new URLSearchParams({
+    'hub.mode': 'subscribe',
+    'hub.topic': topic,
+    'hub.callback': CALLBACK_URL,
+    'hub.verify': 'async'
+  });
+  const res = await fetch(hubUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: params.toString()
+  });
+  if (res.ok) {
+    console.log('Subscribed to WebSub hub');
+  } else {
+    console.error('Failed to subscribe', res.status, await res.text());
+  }
+}
+
+async function checkVideoLive(videoId) {
+  const url = new URL('https://www.googleapis.com/youtube/v3/videos');
+  url.search = new URLSearchParams({
+    part: 'snippet,liveStreamingDetails',
+    id: videoId,
+    key: API_KEY
+  }).toString();
+  const res = await fetch(url);
+  const data = await res.json();
+  if (!res.ok || !data.items || data.items.length === 0) return false;
+  const item = data.items[0];
+  return item.snippet.liveBroadcastContent === 'live' ||
+    (item.liveStreamingDetails && item.liveStreamingDetails.actualStartTime && !item.liveStreamingDetails.actualEndTime);
+}
+
+const server = http.createServer((req, res) => {
+  if (req.url.startsWith('/websub')) {
+    if (req.method === 'GET') {
+      const url = new URL(req.url, `http://${req.headers.host}`);
+      const challenge = url.searchParams.get('hub.challenge');
+      if (challenge) {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end(challenge);
+      } else {
+        res.writeHead(400);
+        res.end();
+      }
+    } else if (req.method === 'POST') {
+      let body = '';
+      req.on('data', chunk => body += chunk);
+      req.on('end', async () => {
+        const match = body.match(/<yt:videoId>([^<]+)<\/yt:videoId>/);
+        if (match) {
+          const id = match[1];
+          try {
+            const live = await checkVideoLive(id);
+            if (live) {
+              console.log('Live stream detected:', `https://www.youtube.com/watch?v=${id}`);
+            } else {
+              console.log('New video but not live:', id);
+            }
+          } catch (err) {
+            console.error('Error verifying video', err);
+          }
+        }
+        res.writeHead(204);
+        res.end();
+      });
+    } else {
+      res.writeHead(405);
+      res.end();
+    }
+  } else {
+    res.writeHead(404);
+    res.end('Not found');
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Listening on port ${PORT}`);
+  subscribe().catch(err => console.error('Subscription failed', err));
+});


### PR DESCRIPTION
## Summary
- introduce a `websub_server.js` Node script that listens for WebSub notifications and filters for live events
- expose new npm script `websub-server`
- document how to use the WebSub listener in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run check-live`
- `node websub_server.js` *(fails: Missing CHANNEL_ID env var)*

------
https://chatgpt.com/codex/tasks/task_e_684ad6081088832eb45f64881ef866b6