### PR TITLE
Add WebSub subscriptions for all channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Multi YouTube Viewer is a progressive web app for watching up to four YouTube vi
 
 ## Check live streams
 
-The **Check Live Streams** button looks for live broadcasts among the channels
+The **Check Live Streams** button (handled by `canal.js`) looks for live broadcasts among the channels
 
 listed in `canals.json`. Each channel entry now includes a `handle` (e.g.
 `@mychannel`) in addition to its `channelId`. If the `API_KEY` constant in
@@ -63,5 +63,28 @@ API_KEY=YOUR_KEY npm run check-live
 
 1. Install dependencies with `npm install`.
 2. Run `npm run fetch-channels` to scrape YouTube channels and update `canals.json` with their IDs and handles.
+
+## WebSub listener
+
+The `websub_server.js` script subscribes to every channel listed in
+`canals.json` that includes a `channelId`. It logs a message whenever a live
+stream starts. Set the environment variables `API_KEY` and optionally
+`CALLBACK_URL` before running it:
+
+```bash
+API_KEY=YOUR_KEY CALLBACK_URL=https://example.com/websub \
+  node websub_server.js
+```
+
+Or run it through npm with:
+
+```bash
+API_KEY=YOUR_KEY CALLBACK_URL=https://example.com/websub \
+  npm run websub-server
+```
+
+The script listens on `PORT` (default `3000`) and automatically subscribes each
+channel to the YouTube hub. Whenever a notification arrives it checks the video
+ID through the YouTube Data API and prints a line if the broadcast is live.
 
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Multi YouTube Viewer PWA",
   "scripts": {
     "fetch-channels": "node scripts/fetch_channels.js",
-    "check-live": "node scripts/check_live.js"
+    "check-live": "node scripts/check_live.js",
+    "websub-server": "node websub_server.js"
   },
   "dependencies": {
     "cheerio": "^1.0.0-rc.12"

--- a/websub_server.js
+++ b/websub_server.js
@@ -1,0 +1,111 @@
+const http = require('http');
+const fs = require('fs/promises');
+const { URL, URLSearchParams } = require('url');
+
+const PORT = process.env.PORT || 3000;
+const CALLBACK_URL = process.env.CALLBACK_URL || `http://localhost:${PORT}/websub`;
+const API_KEY = process.env.API_KEY;
+
+if (!API_KEY) {
+  console.error('Missing API_KEY environment variable');
+  process.exit(1);
+}
+
+async function loadChannelIds() {
+  const data = await fs.readFile('canals.json', 'utf8');
+  const channels = JSON.parse(data);
+  return channels.filter(c => c.channelId).map(c => c.channelId);
+}
+
+async function subscribe(channelId) {
+  const hubUrl = 'https://pubsubhubbub.appspot.com/subscribe';
+  const topic = `https://www.youtube.com/xml/feeds/videos.xml?channel_id=${channelId}`;
+  const params = new URLSearchParams({
+    'hub.mode': 'subscribe',
+    'hub.topic': topic,
+    'hub.callback': CALLBACK_URL,
+    'hub.verify': 'async'
+  });
+  const res = await fetch(hubUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: params.toString()
+  });
+  if (res.ok) {
+    console.log('Subscribed to', channelId);
+  } else {
+    console.error('Failed to subscribe', channelId, res.status, await res.text());
+  }
+}
+
+async function subscribeAll() {
+  const ids = await loadChannelIds();
+  for (const id of ids) {
+    subscribe(id).catch(err => console.error('Subscription failed', id, err));
+  }
+}
+
+async function checkVideoLive(videoId) {
+  const url = new URL('https://www.googleapis.com/youtube/v3/videos');
+  url.search = new URLSearchParams({
+    part: 'snippet,liveStreamingDetails',
+    id: videoId,
+    key: API_KEY
+  }).toString();
+  const res = await fetch(url);
+  const data = await res.json();
+  if (!res.ok || !data.items || data.items.length === 0) return false;
+  const item = data.items[0];
+  return item.snippet.liveBroadcastContent === 'live' ||
+    (item.liveStreamingDetails && item.liveStreamingDetails.actualStartTime && !item.liveStreamingDetails.actualEndTime);
+}
+
+const server = http.createServer((req, res) => {
+  if (req.url.startsWith('/websub')) {
+    if (req.method === 'GET') {
+      const url = new URL(req.url, `http://${req.headers.host}`);
+      const challenge = url.searchParams.get('hub.challenge');
+      if (challenge) {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end(challenge);
+      } else {
+        res.writeHead(400);
+        res.end();
+      }
+    } else if (req.method === 'POST') {
+      let body = '';
+      req.on('data', chunk => body += chunk);
+      req.on('end', async () => {
+        const idMatch = body.match(/<yt:videoId>([^<]+)<\/yt:videoId>/);
+        const channelMatch = body.match(/<yt:channelId>([^<]+)<\/yt:channelId>/);
+        if (idMatch && channelMatch) {
+          const id = idMatch[1];
+          const channelId = channelMatch[1];
+          try {
+            const live = await checkVideoLive(id);
+            if (live) {
+              console.log('Live stream detected from', channelId, ':', `https://www.youtube.com/watch?v=${id}`);
+            } else {
+              console.log('New video but not live from', channelId, ':', id);
+            }
+          } catch (err) {
+            console.error('Error verifying video', err);
+          }
+        }
+        res.writeHead(204);
+        res.end();
+      });
+    } else {
+      res.writeHead(405);
+      res.end();
+    }
+  } else {
+    res.writeHead(404);
+    res.end('Not found');
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Listening on port ${PORT}`);
+  subscribeAll().catch(err => console.error('Subscription setup failed', err));
+});


### PR DESCRIPTION
## Summary
- subscribe to every channel with `channelId` from `canals.json`
- update README explaining the multi-channel WebSub listener

## Testing
- `npm test` *(fails: missing script)*
- `npm run check-live`
- `npm install` *(fails: 403 Forbidden)*
- `node websub_server.js` *(fails: Missing API_KEY env var)*

------
https://chatgpt.com/codex/tasks/task_e_684ad6081088832eb45f64881ef866b6