### PR TITLE
Fix video width calculation

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3,6 +3,7 @@
   --primary-dark: #c2185b;
   --background-start: #f0f4f8;
   --background-end: #d9e2ec;
+  --video-height: 250px;
 }
 
 * {
@@ -79,7 +80,8 @@ input {
 }
 
 iframe {
-  width: 100%;
+  width: min(100%, calc(var(--video-height) * 16 / 9));
+  height: auto;
   aspect-ratio: 16 / 9;
   border: none;
   border-radius: 8px;


### PR DESCRIPTION
## Summary
- add CSS variable for video height
- constrain iframe width to keep a 16:9 aspect ratio while respecting the responsive layout

## Testing
- `npm run check-live` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684ae11dbfc8832eb8b5c5ce2081e3d8