### PR TITLE
Improve live stream detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ The **Check Live Streams** button (handled by `canal.js`) looks for live broadca
 listed in `canals.json`. Each channel entry includes a `handle` (e.g.
 `@mychannel`) in addition to its `channelId`. The script first issues a light
 `HEAD` request to each channel's `/live` page using the handle when available.
-If the response redirects to `/watch?v=VIDEO_ID` the channel is considered live
-and, when an `API_KEY` is configured, a `videos.list` call retrieves the stream
-details. Channels that are not live do not trigger any API request, minimising
-quota usage.
+If a redirect to `/watch?v=VIDEO_ID` is found the channel is considered live.
+When no redirect is returned the page is fetched with `GET` and the video ID is
+extracted from the final URL or HTML. When an `API_KEY` is configured a
+`videos.list` call retrieves the stream details. Channels that are not live do
+not trigger any API request, minimising quota usage.
 
 When a live stream is found it appears in a list under the button. Each result
 includes a **Copiar** button that places the live URL into the first empty video
@@ -46,9 +47,10 @@ the results.
 This project requires **Node.js 18** or newer to run the command line scripts.
 
 You can also check live streams from the terminal. The command
-`npm run check-live` applies the same logic: it issues a `HEAD` request to each
-`/live` page and only consults the Data API when a redirect reveals an active
-stream. It prints a status line for each channel, for example:
+`npm run check-live` applies the same logic: it first sends a `HEAD` request to
+each `/live` page and, if no redirect is present, falls back to a regular fetch
+to extract the video ID. It only consults the Data API once a live stream is
+detected. The script prints a status line for each channel, for example:
 
 ```
 OK MyChannel en emissió: https://www.youtube.com/watch?v=abc123defgh

--- a/scripts/check_live.js
+++ b/scripts/check_live.js
@@ -13,24 +13,37 @@ async function checkChannelLive(channel) {
     ? `https://www.youtube.com/${channel.handle}/live`
     : `https://www.youtube.com/channel/${channel.channelId}/live`;
 
-  const res = await fetch(livePath, { method: 'HEAD', redirect: 'manual' });
+  let videoId = null;
+  let res = await fetch(livePath, { method: 'HEAD', redirect: 'manual' });
   if (res.status >= 300 && res.status < 400) {
     const location = res.headers.get('location');
     const match = location && location.match(/v=([\w-]{11})/);
-    if (match) {
-      const videoId = match[1];
-      let meta = null;
-      if (API_KEY) {
-        const apiUrl =
-          `https://www.googleapis.com/youtube/v3/videos?part=snippet,liveStreamingDetails&id=${videoId}&key=${API_KEY}`;
-        const apiRes = await fetch(apiUrl);
-        const data = await apiRes.json();
-        if (apiRes.ok && data.items && data.items.length > 0) {
-          meta = data.items[0];
-        }
-      }
-      return { url: `https://www.youtube.com/watch?v=${videoId}`, meta };
+    if (match) videoId = match[1];
+  }
+
+  if (!videoId) {
+    res = await fetch(livePath, { redirect: 'follow' });
+    const finalUrl = res.url;
+    let match = finalUrl.match(/[?&]v=([\w-]{11})/);
+    if (!match && res.ok) {
+      const html = await res.text();
+      match = html.match(/"(?:watch\?v=|videoId\":\")([\w-]{11})/);
     }
+    if (match) videoId = match[1];
+  }
+
+  if (videoId) {
+    let meta = null;
+    if (API_KEY) {
+      const apiUrl =
+        `https://www.googleapis.com/youtube/v3/videos?part=snippet,liveStreamingDetails&id=${videoId}&key=${API_KEY}`;
+      const apiRes = await fetch(apiUrl);
+      const data = await apiRes.json();
+      if (apiRes.ok && data.items && data.items.length > 0) {
+        meta = data.items[0];
+      }
+    }
+    return { url: `https://www.youtube.com/watch?v=${videoId}`, meta };
   }
 
   return null;


### PR DESCRIPTION
## Summary
- detect live streams with a GET fallback when the HEAD request doesn't redirect
- document the fallback logic in README

## Testing
- `npm run check-live` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684becfef784832e9eb03847d1b6618f