### PR TITLE
Improve live detection fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,13 @@ The **Check Live Streams** button (handled by `canal.js`) looks for live broadca
 listed in `canals.json`. Each channel entry includes a `handle` (e.g.
 `@mychannel`) in addition to its `channelId`. The script first issues a light
 `HEAD` request to each channel's `/live` page using the handle when available.
-If the response redirects to `/watch?v=VIDEO_ID` the channel is considered live
-and, when an `API_KEY` is configured, a `videos.list` call retrieves the stream
-details. Channels that are not live do not trigger any API request, minimising
-quota usage.
+If a redirect to `/watch?v=VIDEO_ID` is found the channel is considered live.
+When no redirect is returned the page is fetched with `GET` and the video ID is
+extracted from the final URL or HTML. If the handle path fails entirely and a
+`channelId` is known, the script retries the check using the channel ID. When an
+`API_KEY` is configured a `videos.list` call retrieves the stream details.
+Channels that are not live do not trigger any API request, minimising quota
+usage.
 
 When a live stream is found it appears in a list under the button. Each result
 includes a **Copiar** button that places the live URL into the first empty video
@@ -46,9 +49,11 @@ the results.
 This project requires **Node.js 18** or newer to run the command line scripts.
 
 You can also check live streams from the terminal. The command
-`npm run check-live` applies the same logic: it issues a `HEAD` request to each
-`/live` page and only consults the Data API when a redirect reveals an active
-stream. It prints a status line for each channel, for example:
+`npm run check-live` applies the same logic: it sends a `HEAD` request to each
+`/live` page and falls back to a regular fetch when there is no redirect.
+If that check fails and a `channelId` exists, the tool retries with the channel
+ID. It only consults the Data API once a live stream is detected. The script
+prints a status line for each channel, for example:
 
 ```
 OK MyChannel en emissió: https://www.youtube.com/watch?v=abc123defgh

--- a/canal.js
+++ b/canal.js
@@ -25,46 +25,69 @@ async function checkLiveStreams() {
   let cleared = false;
   for (const channel of channels) {
     try {
-      const livePath = channel.handle
-        ? `https://www.youtube.com/${channel.handle}/live`
-        : `https://www.youtube.com/channel/${channel.channelId}/live`;
-      const proxyUrl = `https://corsproxy.io/?${livePath}`;
+      const paths = [];
+      if (channel.handle) {
+        paths.push(`https://www.youtube.com/${channel.handle}/live`);
+      }
+      if (channel.channelId) {
+        paths.push(`https://www.youtube.com/channel/${channel.channelId}/live`);
+      }
+      let videoId = null;
+      for (const livePath of paths) {
+        const proxyUrl = `https://corsproxy.io/?${livePath}`;
 
-      const res = await fetch(proxyUrl, { method: 'HEAD', redirect: 'manual' });
-      if (res.status >= 300 && res.status < 400) {
-        const location = res.headers.get('Location') || res.headers.get('location');
-        const match = location && location.match(/v=([\w-]{11})/);
-        if (match) {
-          const videoId = match[1];
-          let title = channel.name;
-          if (API_KEY) {
-            const apiUrl = `https://www.googleapis.com/youtube/v3/videos?part=snippet,liveStreamingDetails&id=${videoId}&key=${API_KEY}`;
-            const apiRes = await fetch(apiUrl);
-            const data = await apiRes.json();
-            if (apiRes.ok && data.items && data.items.length > 0) {
-              title = data.items[0].snippet.title;
-            } else if (data.error) {
-              console.error('API error', data.error);
-            }
+        let res = await fetch(proxyUrl, { method: 'HEAD', redirect: 'manual' });
+        if (res.status >= 300 && res.status < 400) {
+          const location = res.headers.get('Location') || res.headers.get('location');
+          const match = location && location.match(/v=([\w-]{11})/);
+          if (match) {
+            videoId = match[1];
           }
-          if (!cleared) {
-            results.innerHTML = '';
-            cleared = true;
-          }
-          const li = document.createElement('li');
-          const a = document.createElement('a');
-          a.href = `https://www.youtube.com/watch?v=${videoId}`;
-          a.textContent = title;
-          a.target = '_blank';
-          const copyBtn = document.createElement('button');
-          copyBtn.textContent = 'Copiar';
-          copyBtn.addEventListener('click', () => {
-            fillNextInput(`https://www.youtube.com/watch?v=${videoId}`);
-          });
-          li.appendChild(a);
-          li.appendChild(copyBtn);
-          results.appendChild(li);
         }
+
+        if (!videoId) {
+          res = await fetch(proxyUrl, { redirect: 'follow' });
+          const finalUrl = decodeURIComponent(res.url.replace('https://corsproxy.io/?', ''));
+          let match = finalUrl.match(/[?&]v=([\w-]{11})/);
+          if (!match) {
+            const html = await res.text();
+            match = html.match(/"(?:watch\?v=|videoId\":\")([\w-]{11})/);
+          }
+          if (match) videoId = match[1];
+        }
+
+        if (videoId) break;
+      }
+
+      if (videoId) {
+        let title = channel.name;
+        if (API_KEY) {
+          const apiUrl = `https://www.googleapis.com/youtube/v3/videos?part=snippet,liveStreamingDetails&id=${videoId}&key=${API_KEY}`;
+          const apiRes = await fetch(apiUrl);
+          const data = await apiRes.json();
+          if (apiRes.ok && data.items && data.items.length > 0) {
+            title = data.items[0].snippet.title;
+          } else if (data.error) {
+            console.error('API error', data.error);
+          }
+        }
+        if (!cleared) {
+          results.innerHTML = '';
+          cleared = true;
+        }
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.href = `https://www.youtube.com/watch?v=${videoId}`;
+        a.textContent = title;
+        a.target = '_blank';
+        const copyBtn = document.createElement('button');
+        copyBtn.textContent = 'Copiar';
+        copyBtn.addEventListener('click', () => {
+          fillNextInput(`https://www.youtube.com/watch?v=${videoId}`);
+        });
+        li.appendChild(a);
+        li.appendChild(copyBtn);
+        results.appendChild(li);
       }
     } catch (err) {
       console.error('Error checking channel', channel.channelId, err);


### PR DESCRIPTION
## Summary
- retry live lookups with channel ID if handle check fails
- document the extra fallback in README

## Testing
- `npm run check-live` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684becfef784832e9eb03847d1b6618f