### PR TITLE
Fix live stream detection logic

### DIFF
--- a/canal.js
+++ b/canal.js
@@ -45,23 +45,18 @@ async function checkLiveStreams() {
           }
         }
 
-      let videoId = null;
-      let res = await fetch(proxyUrl, { method: 'HEAD', redirect: 'manual' });
-      if (res.status >= 300 && res.status < 400) {
-        const location = res.headers.get('Location') || res.headers.get('location');
-        const match = location && location.match(/v=([\w-]{11})/);
-        if (match) videoId = match[1];
-      }
-
-      if (!videoId) {
-        res = await fetch(proxyUrl, { redirect: 'follow' });
-        const finalUrl = decodeURIComponent(res.url.replace('https://corsproxy.io/?', ''));
-        let match = finalUrl.match(/[?&]v=([\w-]{11})/);
-        if (!match) {
-          const html = await res.text();
-          match = html.match(/"(?:watch\?v=|videoId\":\")([\w-]{11})/);
+        if (!videoId) {
+          res = await fetch(proxyUrl, { redirect: 'follow' });
+          const finalUrl = decodeURIComponent(res.url.replace('https://corsproxy.io/?', ''));
+          let match = finalUrl.match(/[?&]v=([\w-]{11})/);
+          if (!match) {
+            const html = await res.text();
+            match = html.match(/"(?:watch\?v=|videoId\":\")([\w-]{11})/);
+          }
+          if (match) videoId = match[1];
         }
-        if (match) videoId = match[1];
+
+        if (videoId) break;
       }
 
       if (videoId) {

--- a/scripts/check_live.js
+++ b/scripts/check_live.js
@@ -18,22 +18,26 @@ async function checkChannelLive(channel) {
   }
 
   let videoId = null;
-  let res = await fetch(livePath, { method: 'HEAD', redirect: 'manual' });
-  if (res.status >= 300 && res.status < 400) {
-    const location = res.headers.get('location');
-    const match = location && location.match(/v=([\w-]{11})/);
-    if (match) videoId = match[1];
-  }
-
-  if (!videoId) {
-    res = await fetch(livePath, { redirect: 'follow' });
-    const finalUrl = res.url;
-    let match = finalUrl.match(/[?&]v=([\w-]{11})/);
-    if (!match && res.ok) {
-      const html = await res.text();
-      match = html.match(/"(?:watch\?v=|videoId\":\")([\w-]{11})/);
+  for (const livePath of paths) {
+    let res = await fetch(livePath, { method: 'HEAD', redirect: 'manual' });
+    if (res.status >= 300 && res.status < 400) {
+      const location = res.headers.get('location');
+      const match = location && location.match(/v=([\w-]{11})/);
+      if (match) videoId = match[1];
     }
-    if (match) videoId = match[1];
+
+    if (!videoId) {
+      res = await fetch(livePath, { redirect: 'follow' });
+      const finalUrl = res.url;
+      let match = finalUrl.match(/[?&]v=([\w-]{11})/);
+      if (!match && res.ok) {
+        const html = await res.text();
+        match = html.match(/"(?:watch\?v=|videoId\":\")([\w-]{11})/);
+      }
+      if (match) videoId = match[1];
+    }
+
+    if (videoId) break;
   }
 
   if (videoId) {


### PR DESCRIPTION
## Summary
- restore proper loop structure in `checkLiveStreams` and `check_live.js`
- keep current API key

## Testing
- `node --check canal.js`
- `node --check scripts/check_live.js`
- `npm run check-live` *(fails: fetch errors due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684bf0acebe4832ea5fb6bb5f6509769