### PR TITLE
Add log of HEAD request results

### DIFF
--- a/canal.js
+++ b/canal.js
@@ -37,8 +37,10 @@ async function checkLiveStreams() {
         const proxyUrl = `https://corsproxy.io/?${livePath}`;
 
         let res = await fetch(proxyUrl, { method: 'HEAD', redirect: 'manual' });
+        const headLocation = res.headers.get('Location') || res.headers.get('location');
+        console.log(`[HEAD] ${livePath} -> ${res.status}${headLocation ? ` ${headLocation}` : ''}`);
         if (res.status >= 300 && res.status < 400) {
-          const location = res.headers.get('Location') || res.headers.get('location');
+          const location = headLocation;
           const match = location && location.match(/v=([\w-]{11})/);
           if (match) {
             videoId = match[1];

--- a/scripts/check_live.js
+++ b/scripts/check_live.js
@@ -20,8 +20,10 @@ async function checkChannelLive(channel) {
   let videoId = null;
   for (const livePath of paths) {
     let res = await fetch(livePath, { method: 'HEAD', redirect: 'manual' });
+    const headLocation = res.headers.get('location');
+    console.log(`[HEAD] ${livePath} -> ${res.status}${headLocation ? ` ${headLocation}` : ''}`);
     if (res.status >= 300 && res.status < 400) {
-      const location = res.headers.get('location');
+      const location = headLocation;
       const match = location && location.match(/v=([\w-]{11})/);
       if (match) videoId = match[1];
     }


### PR DESCRIPTION
## Summary
- add logging of `HEAD` results in CLI script
- log `HEAD` results in web UI script

## Testing
- `npm run check-live` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684bf2e6358c832ea205b04a139614dc