### PR TITLE
Add API fallback for live stream detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,14 @@ The **Check Live Streams** button (handled by `canal.js`) looks for live broadca
 listed in `canals.json`. Each channel entry includes a `handle` (e.g.
 `@mychannel`) in addition to its `channelId`. The script first issues a light
 `HEAD` request to each channel's `/live` page using the handle when available.
-If a redirect to `/watch?v=VIDEO_ID` is found the channel is considered live.
-When no redirect is returned the page is fetched with `GET` and the video ID is
-extracted from the final URL or HTML. If an `API_KEY` is configured the
-candidate video is verified through the Data API before being listed so that
-only actual live broadcasts appear in the results. This keeps quota usage low
-while avoiding false positives.
+  If a redirect to `/watch?v=VIDEO_ID` is found the channel is considered live.
+  When no redirect is returned the page is fetched with `GET` and the video ID is
+  extracted from the final URL or HTML. If an `API_KEY` is configured the
+  candidate video is verified through the Data API before being listed so that
+  only actual live broadcasts appear in the results. This keeps quota usage low
+  while avoiding false positives. If the `/live` page yields no video the script
+  now falls back to the YouTube Data API search endpoint to look for ongoing
+  streams on that channel.
 
 
 When a live stream is found it appears in a list under the button. Each result

--- a/canal.js
+++ b/canal.js
@@ -18,6 +18,25 @@ function fillNextInput(url) {
   }
 }
 
+async function getLiveVideoIdFromApi(channelId) {
+  if (!API_KEY || !channelId) return null;
+  try {
+    const url =
+      `https://www.googleapis.com/youtube/v3/search?part=snippet&channelId=${channelId}&eventType=live&type=video&key=${API_KEY}`;
+    const res = await fetch(url);
+    const data = await res.json();
+    if (res.ok && data.items && data.items.length > 0) {
+      const item = data.items.find(
+        it => it.snippet.liveBroadcastContent === 'live' && it.id?.videoId
+      );
+      return item?.id.videoId || null;
+    }
+  } catch (err) {
+    console.error('API search error', err);
+  }
+  return null;
+}
+
 async function checkLiveStreams() {
   const results = document.getElementById('liveResults');
   results.textContent = 'Comprovant...';
@@ -59,6 +78,10 @@ async function checkLiveStreams() {
         }
 
         if (videoId) break;
+      }
+
+      if (!videoId && channel.channelId) {
+        videoId = await getLiveVideoIdFromApi(channel.channelId);
       }
 
       if (videoId) {


### PR DESCRIPTION
## Summary
- add `getLiveVideoIdFromApi` to query YouTube if `/live` page gives no ID
- use this fallback when checking each channel
- document the new behaviour in README

## Testing
- `npm run check-live` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684c25e84f3c832e8b8f30ac72da56e0