### PR TITLE
Add caching and optional API verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ listed in `canals.json`. Each channel entry includes a `handle` (e.g.
   now falls back to the YouTube Data API search endpoint to look for ongoing
   streams on that channel.
 
+The results of each check are cached for five minutes in `localStorage` so the
+same channel isn't queried repeatedly. You can adjust this duration by editing
+the `CACHE_TTL` constant in `canal.js`. Verification with the Data API can be
+disabled by setting `VERIFY_WITH_API` to `false`.
+
 
 When a live stream is found it appears in a list under the button. Each result
 includes a **Copiar** button that places the live URL into the first empty video
@@ -89,6 +94,7 @@ CHANNEL_ID=UC... API_KEY=YOUR_KEY CALLBACK_URL=https://example.com/websub \
 The script listens on `PORT` (default `3000`) and automatically subscribes to
 the YouTube hub. Whenever a notification arrives it checks the video ID through
 the YouTube Data API and prints a line if the broadcast is live.
+Using this listener helps avoid polling the API yourself.
 
 
 

--- a/canal.js
+++ b/canal.js
@@ -3,6 +3,26 @@
 // pàgina /live del canal.
 const API_KEY = 'AIzaSyAgQNSOrxd5EQYZTbLpY63mcafFOP519Jo';
 
+// Quant de temps (ms) es manté a la memòria cau el resultat d'un canal
+const CACHE_TTL = 5 * 60 * 1000; // 5 minuts
+const CACHE_KEY = 'liveCache';
+
+// Si és `true` cada vídeo detectat es validarà amb l'API; en cas contrari només
+// s'emprarà la redirecció/HTML per deduir que és en directe.
+const VERIFY_WITH_API = true;
+
+function loadCache() {
+  try {
+    return JSON.parse(localStorage.getItem(CACHE_KEY)) || {};
+  } catch (_) {
+    return {};
+  }
+}
+
+function saveCache(cache) {
+  localStorage.setItem(CACHE_KEY, JSON.stringify(cache));
+}
+
 async function getChannels() {
   const response = await fetch('canals.json');
   return response.json();
@@ -42,8 +62,35 @@ async function checkLiveStreams() {
   results.textContent = 'Comprovant...';
   const channels = await getChannels();
   let cleared = false;
+  const cache = loadCache();
+  const now = Date.now();
   for (const channel of channels) {
     try {
+      const key = channel.channelId || channel.handle;
+      const cached = cache[key];
+      if (cached && now - cached.ts < CACHE_TTL) {
+        if (cached.videoId) {
+          if (!cleared) {
+            results.innerHTML = '';
+            cleared = true;
+          }
+          const li = document.createElement('li');
+          const a = document.createElement('a');
+          a.href = `https://www.youtube.com/watch?v=${cached.videoId}`;
+          a.textContent = channel.name;
+          if (cached.title) a.title = cached.title;
+          a.target = '_blank';
+          const copyBtn = document.createElement('button');
+          copyBtn.textContent = 'Copiar';
+          copyBtn.addEventListener('click', () => {
+            fillNextInput(`https://www.youtube.com/watch?v=${cached.videoId}`);
+          });
+          li.appendChild(a);
+          li.appendChild(copyBtn);
+          results.appendChild(li);
+        }
+        continue;
+      }
       const paths = [];
       if (channel.handle) {
         paths.push(`https://www.youtube.com/${channel.handle}/live`);
@@ -87,7 +134,7 @@ async function checkLiveStreams() {
       if (videoId) {
         let videoTitle = '';
         let isLive = true;
-        if (API_KEY) {
+        if (VERIFY_WITH_API && API_KEY) {
           const apiUrl = `https://www.googleapis.com/youtube/v3/videos?part=snippet,liveStreamingDetails&id=${videoId}&key=${API_KEY}`;
           const apiRes = await fetch(apiUrl);
           const data = await apiRes.json();
@@ -103,8 +150,10 @@ async function checkLiveStreams() {
           }
         }
         if (!isLive) {
+          cache[key] = { ts: now, videoId: null };
           continue;
         }
+        cache[key] = { ts: now, videoId, title: videoTitle };
         if (!cleared) {
           results.innerHTML = '';
           cleared = true;
@@ -123,6 +172,8 @@ async function checkLiveStreams() {
         li.appendChild(a);
         li.appendChild(copyBtn);
         results.appendChild(li);
+      } else {
+        cache[key] = { ts: now, videoId: null };
       }
     } catch (err) {
       console.error('Error checking channel', channel.channelId, err);
@@ -131,6 +182,7 @@ async function checkLiveStreams() {
   if (!cleared) {
     results.textContent = 'No hi ha transmissions en directe ara mateix.';
   }
+  saveCache(cache);
 }
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- introduce simple live result cache in `canal.js`
- make video verification optional via `VERIFY_WITH_API`
- document caching and WebSub usage

## Testing
- `npm test` *(fails: Missing script)*
- `npm run check-live` *(fails to fetch because of network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684c3303b754832e89c11e7e25c4314f