### PR TITLE
Add logs and Tarragona channel

### DIFF
--- a/canals.json
+++ b/canals.json
@@ -142,6 +142,10 @@
     "handle": "@clubbillarsants-billar8"
   },
   {
+    "name": "CLUB BILLAR TARRAGONA 1",
+    "handle": "@clubbillartarragona1"
+  },
+  {
     "name": "CLUB BILLAR TARRAGONA 2",
     "channelId": "UCUe403LWY9NGRUAglIM2Lug",
     "handle": "@clubbillartarragona2"


### PR DESCRIPTION
## Summary
- improve `check_live.js` with log output to `check_live.log`
- handle log file via `LOG_FILE` env var
- add missing `CLUB BILLAR TARRAGONA 1` channel

## Testing
- `node -c scripts/check_live.js`
- `npm run check-live >/tmp/check-live.out && head -n 20 /tmp/check-live.out`

------
https://chatgpt.com/codex/tasks/task_e_684d3e91dae0832e850c3e1223c05b91