### PR TITLE
Remove hardcoded API key from scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,7 @@ logs
 
 # Mac system files
 .DS_Store
+
+# Local configuration
+config.js
+

--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ name from `canals.json` so you know which channel is live at a glance.
 To use the Data API method you need your own key:
 
 1. Create a project in the Google Cloud Console and enable the *YouTube Data API v3*.
-2. Generate an API key and copy it into `canal.js` by editing the `API_KEY`
-   constant.
+2. Copy `config.sample.js` to `config.js` and set your API key inside the file.
 3. Reload the page and press **Check Live Streams**.
 
 Only public live streams will be returned; unlisted broadcasts won't appear in
@@ -68,8 +67,8 @@ OK MyChannel en emissió: https://www.youtube.com/watch?v=abc123defgh
 KO OtherChannel sense emissió
 ```
 
-An API key is bundled in the project. You can override it by setting the
-`API_KEY` environment variable if desired:
+Provide your API key via a `config.js` file or the `API_KEY` environment
+variable:
 
 ```bash
 API_KEY=YOUR_KEY npm run check-live

--- a/canal.js
+++ b/canal.js
@@ -1,7 +1,6 @@
-// Clau de l'API de YouTube Data a utilitzar per defecte. Pots canviar-la o
-// deixar-la buida si prefereixes emprar el mètode alternatiu que comprova la
-// pàgina /live del canal.
-const API_KEY = 'AIzaSyAgQNSOrxd5EQYZTbLpY63mcafFOP519Jo';
+// Clau de l'API de YouTube Data.
+// Assigna-la a `window.APP_CONFIG.API_KEY` al fitxer `config.js`.
+const API_KEY = window.APP_CONFIG?.API_KEY || '';
 
 // Quant de temps (ms) es manté a la memòria cau el resultat d'un canal
 

--- a/config.sample.js
+++ b/config.sample.js
@@ -1,0 +1,4 @@
+// Copy this file to config.js and set your own YouTube Data API key
+window.APP_CONFIG = {
+  API_KEY: 'YOUR_API_KEY_HERE'
+};

--- a/index.html
+++ b/index.html
@@ -162,6 +162,7 @@
     }
   </script>
 
+  <script src="config.js"></script>
   <script src="https://www.youtube.com/iframe_api"></script>
   <script src="canal.js"></script>
 </body>

--- a/scripts/check_live.js
+++ b/scripts/check_live.js
@@ -10,8 +10,8 @@ function log(msg) {
   logStream.write(line + '\n');
 }
 
-// Default API key if not provided via environment
-const API_KEY = process.env.API_KEY || 'AIzaSyAgQNSOrxd5EQYZTbLpY63mcafFOP519Jo';
+// API key for the YouTube Data API. Provide it via the `API_KEY` environment variable.
+const API_KEY = process.env.API_KEY || '';
 
 async function loadChannels() {
   const data = await fsp.readFile('canals.json', 'utf8');


### PR DESCRIPTION
## Summary
- ignore `config.js` and provide sample file with API key placeholder
- load API key from `window.APP_CONFIG` in `canal.js`
- require API key via env var for `check_live.js`
- load `config.js` from the HTML
- update README with new configuration instructions

## Testing
- `node --check canal.js`
- `node --check scripts/check_live.js`

------
https://chatgpt.com/codex/tasks/task_e_684ef9000728832e82ad94b717b2aecf