### PR TITLE
Fix PWA service worker when site is in subdirectory

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,14 +1,16 @@
 
 const CACHE_NAME = 'algoam-cache-v1';
+// Files required for the app shell. Use relative paths so the service worker
+// also works when the site is served from a subdirectory (e.g. GitHub Pages).
 const ASSETS = [
-  '/',
-  '/index.html',
-  '/manifest.json',
-  '/icon-192.png',
-  '/icon-512.png',
-  '/styles.css',
-  '/canal.js',
-  '/canals.json'
+  './',
+  './index.html',
+  './manifest.json',
+  './icon-192.png',
+  './icon-512.png',
+  './styles.css',
+  './canal.js',
+  './canals.json'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- make service worker cache paths relative so it also works from `/algoam` on GitHub Pages

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684fc413554c832e8f14ef5461b7a85f