### PR TITLE
Add default config file and cache it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,5 +103,4 @@ logs
 .DS_Store
 
 # Local configuration
-config.js
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ name from `canals.json` so you know which channel is live at a glance.
 To use the Data API method you need your own key:
 
 1. Create a project in the Google Cloud Console and enable the *YouTube Data API v3*.
-2. Copy `config.sample.js` to `config.js` and set your API key inside the file.
+2. Edit `config.js` (included with a placeholder key) and set your API key inside the file.
 3. Reload the page and press **Check Live Streams**.
 
 Only public live streams will be returned; unlisted broadcasts won't appear in

--- a/config.js
+++ b/config.js
@@ -1,0 +1,4 @@
+// Configuration for the Multi YouTube Viewer
+window.APP_CONFIG = {
+  API_KEY: ''
+};

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,14 +1,17 @@
 
 const CACHE_NAME = 'algoam-cache-v1';
+// Files required for the app shell. Use relative paths so the service worker
+// also works when the site is served from a subdirectory (e.g. GitHub Pages).
 const ASSETS = [
-  '/',
-  '/index.html',
-  '/manifest.json',
-  '/icon-192.png',
-  '/icon-512.png',
-  '/styles.css',
-  '/canal.js',
-  '/canals.json'
+  './',
+  './index.html',
+  './manifest.json',
+  './icon-192.png',
+  './icon-512.png',
+  './styles.css',
+  './canal.js',
+  './config.js',
+  './canals.json'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- include a default `config.js` so the site loads without 404s
- cache `config.js` in the service worker
- stop ignoring `config.js`
- mention placeholder key in README

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_684fc413554c832e8f14ef5461b7a85f