### PR TITLE
Allow custom CORS proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ To use the Data API method you need your own key:
 
 1. Create a project in the Google Cloud Console and enable the *YouTube Data API v3*.
 2. Edit `config.js` (included with a placeholder key) and set your API key inside the file.
-3. Reload the page and press **Check Live Streams**.
+3. If requests to YouTube return 403 errors, set `CORS_PROXY` in `config.js` to a CORS proxy you control.
+4. Reload the page and press **Check Live Streams**.
 
 Only public live streams will be returned; unlisted broadcasts won't appear in
 the results.

--- a/canal.js
+++ b/canal.js
@@ -1,6 +1,7 @@
 // Clau de l'API de YouTube Data.
 // Assigna-la a `window.APP_CONFIG.API_KEY` al fitxer `config.js`.
 const API_KEY = window.APP_CONFIG?.API_KEY || '';
+const CORS_PROXY = window.APP_CONFIG?.CORS_PROXY || 'https://corsproxy.io/?';
 
 // Quant de temps (ms) es manté a la memòria cau el resultat d'un canal
 
@@ -101,7 +102,7 @@ async function checkLiveStreams() {
       }
       let videoId = null;
       for (const livePath of paths) {
-        const proxyUrl = `https://corsproxy.io/?${livePath}`;
+        const proxyUrl = `${CORS_PROXY}${livePath}`;
 
         let res = await fetch(proxyUrl, { method: 'HEAD', redirect: 'manual' });
         const headLocation = res.headers.get('Location') || res.headers.get('location');
@@ -116,7 +117,7 @@ async function checkLiveStreams() {
 
         if (!videoId) {
           res = await fetch(proxyUrl, { redirect: 'follow' });
-          const finalUrl = decodeURIComponent(res.url.replace('https://corsproxy.io/?', ''));
+          const finalUrl = decodeURIComponent(res.url.replace(CORS_PROXY, ''));
           let match = finalUrl.match(/[?&]v=([\w-]{11})/);
           if (!match) {
             const html = await res.text();

--- a/config.js
+++ b/config.js
@@ -1,4 +1,6 @@
 // Configuration for the Multi YouTube Viewer
 window.APP_CONFIG = {
-  API_KEY: ''
+  API_KEY: '',
+  // Base URL for the CORS proxy used in canal.js
+  CORS_PROXY: 'https://corsproxy.io/?'
 };

--- a/config.sample.js
+++ b/config.sample.js
@@ -1,4 +1,6 @@
 // Copy this file to config.js and set your own YouTube Data API key
 window.APP_CONFIG = {
-  API_KEY: 'YOUR_API_KEY_HERE'
+  API_KEY: 'YOUR_API_KEY_HERE',
+  // Base URL for the CORS proxy used in canal.js
+  CORS_PROXY: 'https://corsproxy.io/?'
 };


### PR DESCRIPTION
## Summary
- make the CORS proxy URL configurable via `config.js`
- document the setting in the README

## Testing
- `npm run check-live` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684ff8672000832e8e1b2176a812b22e