### PR TITLE
Adjust mobile padding for full width videos

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -43,8 +43,17 @@ input {
 }
 
 @media (max-width: 767px) {
+  body {
+    padding: 5px;
+  }
+
   #video-container {
     grid-template-columns: 1fr !important;
+    padding: 0;
+  }
+
+  .video-wrapper {
+    padding: 0;
   }
 
   iframe {


### PR DESCRIPTION
## Summary
- remove extra padding on small screens so videos can span the screen

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685fa5009a54832ea3e45642dc6e1b62