### PR TITLE
Add simple player evolution chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,16 @@
   </details>
 
   <ul id="liveResults"></ul>
+<h2>Jugadors</h2>
+<ul id="playerList"></ul>
+
+<div id="chartModal" class="modal">
+  <div class="modal-content">
+    <button id="closeChart">Tanca</button>
+    <canvas id="playerChart"></canvas>
+  </div>
+</div>
+
 
 
   <div id="video-container"></div>
@@ -165,5 +175,7 @@
   <script src="config.js"></script>
   <script src="https://www.youtube.com/iframe_api"></script>
   <script src="canal.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="players.js"></script>
 </body>
 </html>

--- a/players.js
+++ b/players.js
@@ -1,0 +1,62 @@
+async function loadPlayers() {
+  const res = await fetch('players.json');
+  return res.json();
+}
+
+function createPlayerList(players) {
+  const container = document.getElementById('playerList');
+  players.forEach(player => {
+    const li = document.createElement('li');
+    const a = document.createElement('a');
+    a.href = '#';
+    a.textContent = player.name;
+    a.addEventListener('click', e => {
+      e.preventDefault();
+      showPlayerEvolution(player);
+    });
+    li.appendChild(a);
+    container.appendChild(li);
+  });
+}
+
+function showPlayerEvolution(player) {
+  const ctx = document.getElementById('playerChart').getContext('2d');
+  if (window.currentChart) {
+    window.currentChart.destroy();
+  }
+  window.currentChart = new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: player.history.map((_, i) => `Partida ${i + 1}`),
+      datasets: [{
+        label: player.name,
+        data: player.history,
+        borderColor: 'blue',
+        fill: false
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false
+    }
+  });
+  document.getElementById('chartModal').style.display = 'block';
+}
+
+function setupModal() {
+  const modal = document.getElementById('chartModal');
+  const closeBtn = document.getElementById('closeChart');
+  closeBtn.addEventListener('click', () => {
+    modal.style.display = 'none';
+  });
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  setupModal();
+  try {
+    const players = await loadPlayers();
+    createPlayerList(players);
+  } catch (err) {
+    console.error('Failed to load players', err);
+  }
+});

--- a/players.json
+++ b/players.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "Jugador 1",
+    "history": [1, 3, 2, 4, 5]
+  },
+  {
+    "name": "Jugador 2",
+    "history": [2, 2, 3, 3, 4]
+  },
+  {
+    "name": "Jugador 3",
+    "history": [5, 4, 4, 3, 2]
+  }
+]

--- a/styles.css
+++ b/styles.css
@@ -202,3 +202,45 @@ h1 {
   padding: 6px 12px;
   font-size: 0.8em;
 }
+
+#playerList {
+  list-style: none;
+  padding: 0;
+  margin: 10px auto;
+  max-width: 300px;
+}
+
+#playerList li {
+  margin: 4px 0;
+}
+
+#playerList li a {
+  color: var(--primary-dark);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.modal {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-content {
+  background: #fff;
+  padding: 20px;
+  max-width: 90%;
+  width: 400px;
+  border-radius: 8px;
+}
+
+.modal-content canvas {
+  width: 100%;
+  height: 200px;
+}


### PR DESCRIPTION
## Summary
- list sample players and show modal chart when clicked
- style player list and modal
- load Chart.js and players.js in HTML

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887725a0434832e9e5d127e903486ad