### PR TITLE
Sort player list by average

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ API_KEY=YOUR_KEY npm run check-live
 1. Install dependencies with `npm install`.
 2. Run `npm run fetch-channels` to scrape YouTube channels and update `canals.json` with their IDs and handles.
 
+## Player ranking
+
+The players listed in the application are automatically ordered by their mean score in descending order so that the highest averages appear first.
+
 ## WebSub listener
 
 The `websub_server.js` script subscribes to a channel's WebSub feed and logs a

--- a/players.js
+++ b/players.js
@@ -1,15 +1,21 @@
 async function loadPlayers() {
   const res = await fetch('players.json');
-  return res.json();
+  const players = await res.json();
+  players.forEach(p => {
+    p.mean = p.history.reduce((sum, val) => sum + val, 0) / p.history.length;
+  });
+  players.sort((a, b) => b.mean - a.mean);
+  return players;
 }
 
 function createPlayerList(players) {
   const container = document.getElementById('playerList');
+  container.innerHTML = '';
   players.forEach(player => {
     const li = document.createElement('li');
     const a = document.createElement('a');
     a.href = '#';
-    a.textContent = player.name;
+    a.textContent = `${player.name} - ${player.mean.toFixed(2)}`;
     a.addEventListener('click', e => {
       e.preventDefault();
       showPlayerEvolution(player);


### PR DESCRIPTION
## Summary
- sort players by average history in `players.js`
- show each player's average next to their name
- document ranking order

## Testing
- `node --check players.js`

------
https://chatgpt.com/codex/tasks/task_e_688774043014832e936f8d8037b2fb50