### PR TITLE
Switch to Materialize

### DIFF
--- a/canal.js
+++ b/canal.js
@@ -78,6 +78,7 @@ async function checkLiveStreams() {
             cleared = true;
           }
           const li = document.createElement('li');
+          li.className = 'collection-item';
           const a = document.createElement('a');
           a.href = `https://www.youtube.com/watch?v=${cached.videoId}`;
           a.textContent = channel.name;
@@ -85,8 +86,10 @@ async function checkLiveStreams() {
           a.target = '_blank';
           const copyBtn = document.createElement('button');
           copyBtn.textContent = 'Copiar';
+          copyBtn.className = 'waves-effect waves-light btn';
           copyBtn.addEventListener('click', () => {
             fillNextInput(`https://www.youtube.com/watch?v=${cached.videoId}`);
+            M.toast({html: 'Copiat!'});
           });
           li.appendChild(a);
           li.appendChild(copyBtn);
@@ -164,6 +167,7 @@ async function checkLiveStreams() {
           cleared = true;
         }
         const li = document.createElement('li');
+        li.className = 'collection-item';
         const a = document.createElement('a');
         a.href = `https://www.youtube.com/watch?v=${videoId}`;
         a.textContent = channel.name;
@@ -171,8 +175,10 @@ async function checkLiveStreams() {
         a.target = '_blank';
         const copyBtn = document.createElement('button');
         copyBtn.textContent = 'Copiar';
+        copyBtn.className = 'waves-effect waves-light btn';
         copyBtn.addEventListener('click', () => {
           fillNextInput(`https://www.youtube.com/watch?v=${videoId}`);
+          M.toast({html: 'Copiat!'});
         });
         li.appendChild(a);
         li.appendChild(copyBtn);

--- a/index.html
+++ b/index.html
@@ -13,6 +13,8 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <link rel="apple-touch-icon" href="icon-192.png" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Roboto&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet" />
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
@@ -21,33 +23,52 @@
   <details id="urlToggle" open>
     <summary>Enllaços dels vídeos</summary>
     <form id="videoForm">
-      <input type="url" placeholder="URL vídeo 1" name="url1" required /><br />
-      <input type="url" placeholder="URL vídeo 2" name="url2" /><br />
-      <input type="url" placeholder="URL vídeo 3" name="url3" /><br />
-      <input type="url" placeholder="URL vídeo 4" name="url4" /><br />
+      <div class="input-field">
+        <input id="url1" type="url" name="url1" required />
+        <label for="url1">URL vídeo 1</label>
+      </div>
+      <div class="input-field">
+        <input id="url2" type="url" name="url2" />
+        <label for="url2">URL vídeo 2</label>
+      </div>
+      <div class="input-field">
+        <input id="url3" type="url" name="url3" />
+        <label for="url3">URL vídeo 3</label>
+      </div>
+      <div class="input-field">
+        <input id="url4" type="url" name="url4" />
+        <label for="url4">URL vídeo 4</label>
+      </div>
       <div class="controls">
-        <button type="submit">Carregar vídeos</button>
-        <button type="button" id="playAll">▶️ Reproduir tots</button>
-        <button type="button" id="pauseAll">⏸️ Pausar tots</button>
-        <button type="button" id="checkLive">Check Live Streams</button>
+        <button class="waves-effect waves-light btn" type="submit">Carregar vídeos</button>
+        <button class="waves-effect waves-light btn" type="button" id="playAll">▶️ Reproduir tots</button>
+        <button class="waves-effect waves-light btn" type="button" id="pauseAll">⏸️ Pausar tots</button>
       </div>
     </form>
   </details>
 
-  <ul id="liveResults"></ul>
+  <ul id="liveResults" class="collection"></ul>
 <h2>Jugadors</h2>
-<ul id="playerList"></ul>
+<ul id="playerList" class="collection"></ul>
 
 <div id="chartModal" class="modal">
   <div class="modal-content">
-    <button id="closeChart">Tanca</button>
     <canvas id="playerChart"></canvas>
+  </div>
+  <div class="modal-footer">
+    <a id="closeChart" href="#!" class="modal-close waves-effect waves-green btn-flat">Tanca</a>
   </div>
 </div>
 
 
 
   <div id="video-container"></div>
+
+  <div class="fixed-action-btn">
+    <a id="checkLive" class="btn-floating btn-large red">
+      <i class="large material-icons">live_tv</i>
+    </a>
+  </div>
 
   <script>
     let players = [];
@@ -120,7 +141,7 @@
         const videoId = extractVideoID(convertedUrl);
         if (videoId) {
           const wrapper = document.createElement("div");
-          wrapper.className = "video-wrapper";
+          wrapper.className = "video-wrapper card z-depth-2";
 
           const div = document.createElement("div");
           div.id = "player" + i;
@@ -177,5 +198,11 @@
   <script src="canal.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="players.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      M.AutoInit();
+    });
+  </script>
 </body>
 </html>

--- a/players.js
+++ b/players.js
@@ -13,8 +13,10 @@ function createPlayerList(players) {
   container.innerHTML = '';
   players.forEach(player => {
     const li = document.createElement('li');
+    li.className = 'collection-item';
     const a = document.createElement('a');
-    a.href = '#';
+    a.className = 'blue-text text-darken-2';
+    a.href = '#!';
     a.textContent = `${player.name} - ${player.mean.toFixed(2)}`;
     a.addEventListener('click', e => {
       e.preventDefault();
@@ -46,15 +48,14 @@ function showPlayerEvolution(player) {
       maintainAspectRatio: false
     }
   });
-  document.getElementById('chartModal').style.display = 'block';
+  const modal = document.getElementById('chartModal');
+  const instance = M.Modal.getInstance(modal);
+  instance.open();
 }
 
 function setupModal() {
   const modal = document.getElementById('chartModal');
-  const closeBtn = document.getElementById('closeChart');
-  closeBtn.addEventListener('click', () => {
-    modal.style.display = 'none';
-  });
+  M.Modal.init(modal);
 }
 
 document.addEventListener('DOMContentLoaded', async () => {

--- a/styles.css
+++ b/styles.css
@@ -99,9 +99,6 @@ input:focus {
 
 .video-wrapper {
   width: 100%;
-  background: #fff;
-  border-radius: 8px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
   padding: 10px;
   display: flex;
   justify-content: center;
@@ -135,7 +132,7 @@ iframe {
   }
 }
 
-button {
+button:not(.btn) {
   margin: 5px;
   padding: 10px 20px;
   font-size: 1em;
@@ -148,7 +145,7 @@ button {
   transition: background 0.3s, transform 0.2s;
 }
 
-button:hover {
+button:not(.btn):hover {
   transform: translateY(-2px);
   filter: brightness(1.1);
 }
@@ -226,26 +223,6 @@ h1 {
   color: var(--primary-dark);
   text-decoration: underline;
   cursor: pointer;
-}
-
-.modal {
-  display: none;
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.5);
-  align-items: center;
-  justify-content: center;
-}
-
-.modal-content {
-  background: #fff;
-  padding: 20px;
-  max-width: 90%;
-  width: 400px;
-  border-radius: 8px;
 }
 
 .modal-content canvas {


### PR DESCRIPTION
## Summary
- style page using Materialize CSS components
- show live results and players in styled collections
- open the player chart using a Materialize modal
- offer floating button to check channels and copy-to-clipboard toasts

## Testing
- `npm run check-live` *(fails: fetch errors)*

------
https://chatgpt.com/codex/tasks/task_e_6887790fc87c832e9f31a6d2909a9457