### PR TITLE
Add button to search live streams

### DIFF
--- a/canal.js
+++ b/canal.js
@@ -205,4 +205,8 @@ document.addEventListener('DOMContentLoaded', () => {
   if (btn) {
     btn.addEventListener('click', checkLiveStreams);
   }
+  const fab = document.getElementById('checkLiveFab');
+  if (fab) {
+    fab.addEventListener('click', checkLiveStreams);
+  }
 });

--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@
         <button class="waves-effect waves-light btn" type="submit">Carregar vídeos</button>
         <button class="waves-effect waves-light btn" type="button" id="playAll">▶️ Reproduir tots</button>
         <button class="waves-effect waves-light btn" type="button" id="pauseAll">⏸️ Pausar tots</button>
+        <button class="waves-effect waves-light btn" type="button" id="checkLive">Cercar directes</button>
       </div>
     </form>
   </details>
@@ -51,7 +52,7 @@
   <div id="video-container"></div>
 
   <div class="fixed-action-btn">
-    <a id="checkLive" class="btn-floating btn-large red">
+    <a id="checkLiveFab" class="btn-floating btn-large red">
       <i class="large material-icons">live_tv</i>
     </a>
   </div>


### PR DESCRIPTION
## Summary
- add visible button labeled "Cercar directes" for checking live streams
- keep floating action button but rename its ID
- let canal.js handle the new button and the renamed floating button

## Testing
- `npm run check-live` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68885d2ee168832eae673fc5f885b5cf