### PR TITLE
Add download button for each video

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,6 +133,15 @@
           const div = document.createElement("div");
           div.id = "player" + i;
           wrapper.appendChild(div);
+
+          const downloadBtn = document.createElement("a");
+          downloadBtn.href = convertedUrl;
+          downloadBtn.textContent = "⬇️ Descarregar";
+          downloadBtn.className = "waves-effect waves-light btn";
+          downloadBtn.target = "_blank";
+          downloadBtn.setAttribute("download", "");
+          wrapper.appendChild(downloadBtn);
+
           container.appendChild(wrapper);
 
           loadedCount++;

--- a/styles.css
+++ b/styles.css
@@ -103,7 +103,12 @@ input:focus {
   width: 100%;
   padding: 10px;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+}
+
+.video-wrapper .btn {
+  margin-top: 8px;
 }
 
 .controls {


### PR DESCRIPTION
## Summary
- add a download button beside each loaded video
- stack video elements vertically and style button spacing

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68c0165a0974832e869fe63675ea1efc