### PR TITLE
Remove video download buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,24 +108,6 @@
       }
     }
 
-    async function downloadVideo(url, filename) {
-      try {
-        const response = await fetch(url);
-        const blob = await response.blob();
-        const blobUrl = URL.createObjectURL(blob);
-        const a = document.createElement("a");
-        a.href = blobUrl;
-        a.download = filename || "video.mp4";
-        document.body.appendChild(a);
-        a.click();
-        a.remove();
-        URL.revokeObjectURL(blobUrl);
-      } catch (err) {
-        console.error("Error baixant el vídeo:", err);
-        alert("No s'ha pogut descarregar el vídeo.");
-      }
-    }
-
     function processForm() {
       const container = document.getElementById("video-container");
       container.innerHTML = "";
@@ -151,16 +133,6 @@
           const div = document.createElement("div");
           div.id = "player" + i;
           wrapper.appendChild(div);
-
-
-          const downloadBtn = document.createElement("button");
-          downloadBtn.textContent = "⬇️ Descarregar";
-          downloadBtn.className = "waves-effect waves-light btn";
-          downloadBtn.addEventListener("click", () =>
-            downloadVideo(convertedUrl, `video${i}.mp4`)
-          );
-
-          wrapper.appendChild(downloadBtn);
 
           container.appendChild(wrapper);
 


### PR DESCRIPTION
## Summary
- remove the download helper and related error alert
- stop rendering download buttons alongside loaded videos

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693693971704832eac9ff152ffa6c312)